### PR TITLE
gentoo: Change source to the master mirrors

### DIFF
--- a/fetch-scripts/gentoo-distfiles
+++ b/fetch-scripts/gentoo-distfiles
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Modified from http://www.gentoo.org/doc/en/rsync.xml#doc_chap3
 
-RSYNCSOURCE=rsync://mirrors.rit.edu/gentoo
+RSYNCSOURCE=rsync://masterdistfiles.gentoo.org/gentoo
 BASEDIR=${MIRRORDIR}/gentoo-distfiles
 
 rsync --recursive --times --links --hard-links \

--- a/fetch-scripts/gentoo-portage
+++ b/fetch-scripts/gentoo-portage
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Modified from http://www.gentoo.org/doc/en/rsync.xml#doc_chap3
 
-RSYNCSOURCE=rsync://rsync.us.gentoo.org/gentoo-portage
+RSYNCSOURCE=rsync://masterportage.gentoo.org/gentoo-portage
 BASEDIR=${MIRRORDIR}/gentoo-portage
 
 rsync --recursive --times --links --hard-links \


### PR DESCRIPTION
`gentoo-portage` has been sad because one of our old upstreams is refusing connections. I took the liberty to refresh our upstream to bring in line with instructions for `gentoo-portage` (["Rsync mirror"](https://wiki.gentoo.org/wiki/Project:Infrastructure/Mirrors/Rsync)) and `gentoo-distfiles` (["source mirror"](https://wiki.gentoo.org/wiki/Project:Infrastructure/Mirrors/Source)). I feel justified in using the master mirrors because we're already supposed to be a [primary for distfiles](https://www.gentoo.org/downloads/mirrors/), and we can easily apply to be primary for portage as well.